### PR TITLE
Only show categories with cookies attached and don't load cookie manager when no cookies are defined

### DIFF
--- a/plugins/system/cookiemanager/cookiemanager.php
+++ b/plugins/system/cookiemanager/cookiemanager.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package     Joomla.Plugin
  * @subpackage  System.cookiemanager
@@ -46,23 +47,23 @@ class PlgSystemCookiemanager extends CMSPlugin
 	 * @var    \Joomla\Database\DatabaseDriver
 	 * @since  __DEPLOY_VERSION__
 	 */
-	 protected $db;
+	protected $db;
 
-	 /**
-	  * Cookie settings scripts
-	  *
-	  * @var    object
-	  * @since  __DEPLOY_VERSION__
-	  */
-	 protected $cookieScripts;
+	/**
+	 * Cookie settings scripts
+	 *
+	 * @var    object
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $cookieScripts;
 
-	 /**
-	  * Cookie categories
-	  *
-	  * @var    object
-	  * @since  __DEPLOY_VERSION__
-	  */
-	  protected $cookieCategories;
+	/**
+	 * Cookie categories
+	 *
+	 * @var    object
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $cookieCategories;
 
 	/**
 	 * Add assets for the cookie banners.
@@ -98,7 +99,7 @@ class PlgSystemCookiemanager extends CMSPlugin
 
 		$db    = $this->db;
 		$query = $db->getQuery(true)
-			->select($db->quoteName(['c.id','c.alias','a.cookie_name','a.cookie_desc','a.exp_period','a.exp_value']))
+			->select($db->quoteName(['c.id', 'c.alias', 'a.cookie_name', 'a.cookie_desc', 'a.exp_period', 'a.exp_value']))
 			->from($db->quoteName('#__categories', 'c'))
 			->join(
 				'RIGHT',
@@ -108,7 +109,7 @@ class PlgSystemCookiemanager extends CMSPlugin
 
 		$this->cookies = $db->setQuery($query)->loadObjectList();
 
-		if(!empty($this->cookies))
+		if (!empty($this->cookies))
 		{
 			// Load required assets
 			$assets = $this->app->getDocument()->getWebAssetManager();
@@ -126,11 +127,12 @@ class PlgSystemCookiemanager extends CMSPlugin
 		}
 
 		$query = $db->getQuery(true)
-			->select($db->quoteName(['id','title','alias','description']))
+			->select($db->quoteName(['id', 'title', 'alias', 'description']))
 			->from($db->quoteName('#__categories'))
-			->where([
-				$db->quoteName('extension') . ' = ' . $db->quote('com_cookiemanager'),
-				$db->quoteName('published') . ' =  1',
+			->where(
+				[
+					$db->quoteName('extension') . ' = ' . $db->quote('com_cookiemanager'),
+					$db->quoteName('published') . ' =  1',
 				]
 			)
 			->order($db->quoteName('lft'));
@@ -138,7 +140,7 @@ class PlgSystemCookiemanager extends CMSPlugin
 		$this->cookieCategories = $db->setQuery($query)->loadObjectList();
 
 		$query = $db->getQuery(true)
-			->select($db->quoteName(['a.type','a.position','a.code','a.catid']))
+			->select($db->quoteName(['a.type', 'a.position', 'a.code', 'a.catid']))
 			->from($db->quoteName('#__cookiemanager_scripts', 'a'))
 			->where($db->quoteName('a.published') . ' =  1')
 			->join(
@@ -178,7 +180,6 @@ class PlgSystemCookiemanager extends CMSPlugin
 		ob_start();
 		include PluginHelper::getLayoutPath('system', 'cookiemanager');
 		$this->bannerContent = ob_get_clean();
-
 	}
 
 	/**
@@ -203,7 +204,7 @@ class PlgSystemCookiemanager extends CMSPlugin
 			return;
 		}
 
-		if(!empty($this->cookies))
+		if (!empty($this->cookies))
 		{
 			echo '<button class="preview btn btn-info" data-bs-toggle="modal" data-bs-target="#consentBanner">' . Text::_('COM_COOKIEMANAGER_PREVIEW_BUTTON_TEXT') . '</button>';
 
@@ -250,7 +251,6 @@ class PlgSystemCookiemanager extends CMSPlugin
 
 									echo preg_replace('/<body[^>]+>\K/i', $value->code, $html);
 								}
-
 								else
 								{
 									$html = ob_get_contents();

--- a/plugins/system/cookiemanager/tmpl/default.php
+++ b/plugins/system/cookiemanager/tmpl/default.php
@@ -26,8 +26,18 @@ $consentBannerBody .= '<h5>' . Text::_('COM_COOKIEMANAGER_MANAGE_CONSENT_PREFERE
 
 foreach ($this->cookieCategories as $key => $value)
 {
-	$consentBannerBody .= '<li class="cookie-cat form-check form-check-inline"><label>' . $value->title . '<span class="ms-4 form-check-inline form-switch"><input class="form-check-input" data-cookiecategory="'
-	. $value->alias . '" type=checkbox></span></label></li>';
+	foreach ($this->cookies as $key => $cookieValue)
+	{
+		if (!empty($value))
+		{
+			if ($value->id == $cookieValue->id)
+			{
+				$consentBannerBody .= '<li class="cookie-cat form-check form-check-inline"><label>' . $value->title . '<span class="ms-4 form-check-inline form-switch"><input class="form-check-input" data-cookiecategory="'
+				. $value->alias . '" type=checkbox></span></label></li>';
+				break;
+			}
+		}
+	}
 }
 
 $consentBannerBody .= '</ul>';
@@ -60,19 +70,24 @@ $settingsBannerBody .= '<p>' . Text::_('COM_COOKIEMANAGER_FIELD_CONSENT_OPT_IN_L
 
 foreach ($this->cookieCategories as $catKey => $catValue)
 {
-	$settingsBannerBody .= '<h4>' . $catValue->title . '<span class="form-check-inline form-switch float-end">' .
-	'<input class="form-check-input " type="checkbox" data-cookie-category="' . $catValue->alias . '"></span></h4>' . $catValue->description;
-
-	$settingsBannerBody .= '<a class="text-decoration-none" data-bs-toggle="collapse" href="#' . $catValue->alias . '" role="button" aria-expanded="false" '
-	. 'aria-controls="' . $catValue->alias . '">' . Text::_('COM_COOKIEMANAGER_PREFERENCES_MORE_BUTTON_TEXT') . '</a><div class="collapse" id="' . $catValue->alias . '">';
-	$table = '<table class="table"><thead><tr><th scope="col">' . Text::_('COM_COOKIEMANAGER_TABLE_HEAD_COOKIENAME') . '</th><th scope="col">' . Text::_('COM_COOKIEMANAGER_TABLE_HEAD_DESCRIPTION') . '</th><th scope="col">' . Text::_('COM_COOKIEMANAGER_TABLE_HEAD_EXPIRATION') . '</th></tr></thead><tbody>';
-
-	foreach ($cookies as $key => $value)
+	$hasCookies=true;
+	foreach ($this->cookies as $key => $value)
 	{
 		if (!empty($value))
 		{
 			if ($catValue->id == $value->id)
 			{
+				if($hasCookies)
+				{
+					$settingsBannerBody .= '<h4>' . $catValue->title . '<span class="form-check-inline form-switch float-end">' .
+					'<input class="form-check-input " type="checkbox" data-cookie-category="' . $catValue->alias . '"></span></h4>' . $catValue->description;
+
+					$settingsBannerBody .= '<a class="text-decoration-none" data-bs-toggle="collapse" href="#' . $catValue->alias . '" role="button" aria-expanded="false" '
+					. 'aria-controls="' . $catValue->alias . '">' . Text::_('COM_COOKIEMANAGER_PREFERENCES_MORE_BUTTON_TEXT') . '</a><div class="collapse" id="' . $catValue->alias . '">';
+					$table = '<table class="table"><thead><tr><th scope="col">' . Text::_('COM_COOKIEMANAGER_TABLE_HEAD_COOKIENAME') . '</th><th scope="col">' . Text::_('COM_COOKIEMANAGER_TABLE_HEAD_DESCRIPTION') . '</th><th scope="col">' . Text::_('COM_COOKIEMANAGER_TABLE_HEAD_EXPIRATION') . '</th></tr></thead><tbody>';
+					$hasCookies=false;
+				}
+
 				if ($value->exp_period == -1)
 				{
 					$value->exp_period = "Forever";
@@ -93,8 +108,11 @@ foreach ($this->cookieCategories as $catKey => $catValue)
 		}
 	}
 
-	$table .= '</tbody></table>';
-	$settingsBannerBody .= $table . '</div>';
+	if(!$hasCookies)
+	{
+		$table .= '</tbody></table>';
+		$settingsBannerBody .= $table . '</div>';
+	}
 }
 
 echo HTMLHelper::_(

--- a/plugins/system/cookiemanager/tmpl/default.php
+++ b/plugins/system/cookiemanager/tmpl/default.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package     Joomla.Plugin
  * @subpackage  System.cookiemanager
@@ -18,7 +19,8 @@ $menuitem = $sitemenu->getItem($params->get('policylink', ''));
 
 $consentBannerBody = '<p>' . Text::_('COM_COOKIEMANAGER_COOKIE_BANNER_DESCRIPTION') . '</p>';
 
-if ($menuitem) {
+if ($menuitem)
+{
 	$consentBannerBody .= '<p>' . HTMLHelper::_('link', Route::_($menuitem->link), Text::_('COM_COOKIEMANAGER_VIEW_COOKIE_POLICY')) . '</p>';
 }
 
@@ -46,21 +48,22 @@ echo HTMLHelper::_(
 	'bootstrap.renderModal',
 	'consentBanner',
 	[
-			'title' => Text::_('COM_COOKIEMANAGER_COOKIE_BANNER_TITLE'),
-			'footer' => '<button type="button" id="consentConfirmChoice" class="btn btn-info" data-bs-dismiss="modal">'
+		'title' => Text::_('COM_COOKIEMANAGER_COOKIE_BANNER_TITLE'),
+		'footer' => '<button type="button" id="consentConfirmChoice" class="btn btn-info" data-bs-dismiss="modal">'
 			. Text::_('COM_COOKIEMANAGER_CONFIRM_MY_CHOICES_BUTTON_TEXT') . '</button>'
 			. '<button type="button" class="btn btn-info" data-bs-toggle="modal" data-bs-dismiss="modal" data-bs-target="#settingsBanner">'
 			. Text::_('COM_COOKIEMANAGER_MORE_DETAILS') . '</button>'
 			. '<button type="button" data-button="acceptAllCookies" class="btn btn-info" data-bs-dismiss="modal">'
 			. Text::_('COM_COOKIEMANAGER_ACCEPT_ALL_COOKIES_BUTTON_TEXT') . '</button>',
 
-		],
+	],
 	$consentBannerBody
 );
 
 $settingsBannerBody = '<p>' . Text::_('COM_COOKIEMANAGER_PREFERENCES_DESCRIPTION') . '</p>';
 
-if ($menuitem) {
+if ($menuitem)
+{
 	$settingsBannerBody .= '<p>' . HTMLHelper::_('link', Route::_($menuitem->link), Text::_('COM_COOKIEMANAGER_VIEW_COOKIE_POLICY')) . '</p>';
 }
 
@@ -70,22 +73,22 @@ $settingsBannerBody .= '<p>' . Text::_('COM_COOKIEMANAGER_FIELD_CONSENT_OPT_IN_L
 
 foreach ($this->cookieCategories as $catKey => $catValue)
 {
-	$hasCookies=true;
+	$hasCookies = true;
 	foreach ($this->cookies as $key => $value)
 	{
 		if (!empty($value))
 		{
 			if ($catValue->id == $value->id)
 			{
-				if($hasCookies)
+				if ($hasCookies)
 				{
 					$settingsBannerBody .= '<h4>' . $catValue->title . '<span class="form-check-inline form-switch float-end">' .
-					'<input class="form-check-input " type="checkbox" data-cookie-category="' . $catValue->alias . '"></span></h4>' . $catValue->description;
+						'<input class="form-check-input " type="checkbox" data-cookie-category="' . $catValue->alias . '"></span></h4>' . $catValue->description;
 
 					$settingsBannerBody .= '<a class="text-decoration-none" data-bs-toggle="collapse" href="#' . $catValue->alias . '" role="button" aria-expanded="false" '
-					. 'aria-controls="' . $catValue->alias . '">' . Text::_('COM_COOKIEMANAGER_PREFERENCES_MORE_BUTTON_TEXT') . '</a><div class="collapse" id="' . $catValue->alias . '">';
+						. 'aria-controls="' . $catValue->alias . '">' . Text::_('COM_COOKIEMANAGER_PREFERENCES_MORE_BUTTON_TEXT') . '</a><div class="collapse" id="' . $catValue->alias . '">';
 					$table = '<table class="table"><thead><tr><th scope="col">' . Text::_('COM_COOKIEMANAGER_TABLE_HEAD_COOKIENAME') . '</th><th scope="col">' . Text::_('COM_COOKIEMANAGER_TABLE_HEAD_DESCRIPTION') . '</th><th scope="col">' . Text::_('COM_COOKIEMANAGER_TABLE_HEAD_EXPIRATION') . '</th></tr></thead><tbody>';
-					$hasCookies=false;
+					$hasCookies = false;
 				}
 
 				if ($value->exp_period == -1)
@@ -100,15 +103,15 @@ foreach ($this->cookieCategories as $catKey => $catValue)
 				}
 
 				$table .= '<tr>'
-				. '<td>' . $value->cookie_name . '</td>'
-				. '<td>' . $value->cookie_desc . '</td>'
-				. '<td>' . $value->exp_value . ' ' . $value->exp_period . '</td>'
-				. '</tr>';
+					. '<td>' . $value->cookie_name . '</td>'
+					. '<td>' . $value->cookie_desc . '</td>'
+					. '<td>' . $value->exp_value . ' ' . $value->exp_period . '</td>'
+					. '</tr>';
 			}
 		}
 	}
 
-	if(!$hasCookies)
+	if (!$hasCookies)
 	{
 		$table .= '</tbody></table>';
 		$settingsBannerBody .= $table . '</div>';


### PR DESCRIPTION
Partial pull Request for Issue #14 

### Summary of Changes

- Cookie manager will not load in frontend if there are no cookies defined
- Consent banner modal in the frontend will only show the categories which have cookies attached

### Testing Instructions
- Don't create any cookies and check in the frontend the cookie manager settings button shouldn't be visible
- Create cookies and add them to any category, these categories should be visible in consent banner model in the frontend
- Create categories but don't add any cookies to them, these categories should not be shown in consent banner model in the frontend


### Actual result BEFORE applying this Pull Request
- Cookie manager settings button is shown in the frontend even if there are no cookies defined
- Categories which don't have any cookies attached to them are also shown in the consent banner model


### Expected result AFTER applying this Pull Request
- Cookie manager settings button is only visible when at least one cookie is defined
- Only categories which have at least one cookie attached to them are shown in the consent banner model


