### PR TITLE
Fixes category selection and creation of random categories

### DIFF
--- a/administrator/components/com_cookiemanager/src/Model/CookieModel.php
+++ b/administrator/components/com_cookiemanager/src/Model/CookieModel.php
@@ -138,14 +138,6 @@ class CookieModel extends AdminModel
 	 */
 	protected function preprocessForm(Form $form, $data, $group = 'content')
 	{
-		if ($this->canCreateCategory())
-		{
-			$form->setFieldAttribute('catid', 'allowAdd', 'true');
-
-			// Add a prefix for categories created on the fly.
-			$form->setFieldAttribute('catid', 'customPrefix', '#new#');
-		}
-
 		parent::preprocessForm($form, $data, $group);
 	}
 
@@ -202,56 +194,6 @@ class CookieModel extends AdminModel
 	public function save($data)
 	{
 		$input = Factory::getApplication()->input;
-
-		// Create new category, if needed.
-		$createCategory = true;
-
-		// If category ID is provided, check if it's valid.
-		if (is_numeric($data['catid']) && $data['catid'])
-		{
-			$createCategory = !CategoriesHelper::validateCategoryId($data['catid'], 'com_cookiemanger');
-		}
-
-		// Save New Category
-		if ($createCategory && $this->canCreateCategory())
-		{
-			$category = [
-				// Remove #new# prefix, if exists.
-				'title'     => strpos($data['catid'], '#new#') === 0 ? substr($data['catid'], 5) : $data['catid'],
-				'parent_id' => 1,
-				'extension' => 'com_cookiemanager',
-				'language'  => $data['language'],
-				'published' => 1,
-			];
-
-			/** @var \Joomla\Component\Categories\Administrator\Model\CategoryModel $categoryModel */
-			$categoryModel = Factory::getApplication()->bootComponent('com_categories')
-				->getMVCFactory()->createModel('Category', 'Administrator', ['ignore_request' => true]);
-
-			// Create new category.
-			if (!$categoryModel->save($category))
-			{
-				$this->setError($categoryModel->getError());
-
-				return false;
-			}
-
-			// Get the new category ID.
-			$data['catid'] = $categoryModel->getState('category.id');
-		}
-
 		return parent::save($data);
-	}
-
-	/**
-	 * Is the user allowed to create an on the fly category?
-	 *
-	 * @return  boolean
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	private function canCreateCategory()
-	{
-		return Factory::getUser()->authorise('core.create', 'com_cookiemanager');
 	}
 }

--- a/administrator/components/com_cookiemanager/src/Model/CookieModel.php
+++ b/administrator/components/com_cookiemanager/src/Model/CookieModel.php
@@ -194,6 +194,7 @@ class CookieModel extends AdminModel
 	public function save($data)
 	{
 		$input = Factory::getApplication()->input;
+
 		return parent::save($data);
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #15

### Summary of Changes
Deleted a function which was creating category on the fly as this function was generating a category id and creating a new category while assigning category to a cookie in cookie edit view.


### Testing Instructions
- Create a new category in Cookie Manger
- Create a new cookie
- In the Cookie Edit view, assign this cookie to the new category created
- This should not create a new category with random number and cookie should be assigned to the selected category without any problem



### Actual result BEFORE applying this Pull Request
New category with random number is created when a cookie is assigned to a category in Edit cookie view


### Expected result AFTER applying this Pull Request
No random category generated 



