### PR TITLE
Modal Protection

### DIFF
--- a/plugins/system/cookiemanager/cookiemanager.php
+++ b/plugins/system/cookiemanager/cookiemanager.php
@@ -198,6 +198,12 @@ class PlgSystemCookiemanager extends CMSPlugin
 			return;
 		}
 
+		// Are we in a modal?
+		if ($this->app->input->get('tmpl', '', 'cmd') === 'component')
+		{
+			return;
+		}
+
 		echo $this->bannerContent;
 
 		// Return early in case of AJAX request

--- a/plugins/system/cookiemanager/cookiemanager.php
+++ b/plugins/system/cookiemanager/cookiemanager.php
@@ -78,6 +78,12 @@ class PlgSystemCookiemanager extends CMSPlugin
 			return;
 		}
 
+		// Are we in a modal?
+		if ($this->app->input->get('tmpl', '', 'cmd') === 'component')
+		{
+			return;
+		}
+
 		HTMLHelper::_('bootstrap.collapse');
 
 		ob_start();


### PR DESCRIPTION
Prevent script running in a modal.

Easiest way to test is to open an article for editing on the frontend and then use any of the cmscontent buttons. These open in a modal. Before the PR the cookie consent button etc is present. After the PR the button is not present.