### PR TITLE
Move's consens banner code to the beginning of the page 

### DIFF
--- a/plugins/system/cookiemanager/cookiemanager.php
+++ b/plugins/system/cookiemanager/cookiemanager.php
@@ -175,6 +175,7 @@ class PlgSystemCookiemanager extends CMSPlugin
 		ob_start();
 		include PluginHelper::getLayoutPath('system', 'cookiemanager');
 		$this->bannerContent = ob_get_clean();
+		echo $this->bannerContent;
 
 	}
 
@@ -192,7 +193,7 @@ class PlgSystemCookiemanager extends CMSPlugin
 			return;
 		}
 
-		echo $this->bannerContent;
+		
 
 		// Return early in case of AJAX request
 		if ($this->app->input->get('format') === 'json')

--- a/plugins/system/cookiemanager/cookiemanager.php
+++ b/plugins/system/cookiemanager/cookiemanager.php
@@ -176,7 +176,6 @@ class PlgSystemCookiemanager extends CMSPlugin
 		include PluginHelper::getLayoutPath('system', 'cookiemanager');
 		$this->bannerContent = ob_get_clean();
 		echo $this->bannerContent;
-
 	}
 
 	/**
@@ -192,8 +191,6 @@ class PlgSystemCookiemanager extends CMSPlugin
 		{
 			return;
 		}
-
-		
 
 		// Return early in case of AJAX request
 		if ($this->app->input->get('format') === 'json')


### PR DESCRIPTION
Pull Request for Issue # . Move consens banner code to the beginning of the page 

### Summary of Changes
Moved the consens banner code to the beginning of the page below the body tag

### Actual result BEFORE applying this Pull Request
the consens banner code was at the end screenshot attached below
![before](https://user-images.githubusercontent.com/69755312/180136122-7d98ce62-8062-40ea-87a3-e18596e70047.png)



### Result AFTER applying this Pull Request
The consens banner code is now at the top below body tag screenshot attached below
![After](https://user-images.githubusercontent.com/69755312/180136323-4295d3c3-42ab-4644-80eb-6d4b33749078.png)
